### PR TITLE
fix #13: send to tmux in chunks

### DIFF
--- a/sendtext.py
+++ b/sendtext.py
@@ -67,6 +67,7 @@ def sendtext(cmd):
         subprocess.Popen(args)
 
     elif prog == "tmux":
+        cmd = clean(cmd) + "\n"
         progpath = RBoxSettings("tmux", "tmux")
         # `tmux set-buffer` fails if more than 16352 characters are
         # passed to it. Send in chunks to avoid the problem.


### PR DESCRIPTION
Fixed #13 by sending to `tmux` in chunks of 15000 characters.

Tested on Debian testing, `tmux 1.9-6`, `Sublime Text build 3066`.

This is my first ever pull request on GitHub. Please let me know if I violated any more or less obvious conventions.
