### PR TITLE
Fix R Markdown syntax detection of closing backtick for inline R code

### DIFF
--- a/syntax/R Markdown.sublime-syntax
+++ b/syntax/R Markdown.sublime-syntax
@@ -971,10 +971,10 @@ contexts:
           set:
             - meta_scope: markup.raw.code-fence.markdown
             - meta_content_scope: source.r
-            - include: "R Extended.sublime-syntax"
             - match: '[ ]{,3}(```)\s*$'
               scope: punctuation.definition.raw.code-fence.end.markdown
               pop: true
+            - include: "R Extended.sublime-syntax"
 
   rcode-span:
     - match: (`+)(r) (?!`)
@@ -984,7 +984,6 @@ contexts:
       push:
         - meta_scope: markup.raw.inline.markdown
         - meta_content_scope: source.r
-        - include: "R Extended.sublime-syntax"
         - match: \1(?!`)
           scope: punctuation.definition.raw.end.markdown
           pop: true
@@ -992,6 +991,7 @@ contexts:
         - match: ^\s*$\n?
           scope: invalid.illegal.non-terminated.raw.markdown
           pop: true
+        - include: "R Extended.sublime-syntax"
 
   latex-math:
     - match: \\\$


### PR DESCRIPTION
The syntax definition for Rmd files was not correctly detecting closing backticks in inline R code (rcode-span context).  Here is an example:

```
`r Metab` while holding `Mass` fixed
```

The text from the 'M' in Metab all the way to the final 's' in Mass is incorrectly scoped as "source.r".  

I think the issue is that including "R Extended.sublime-syntax" in the the rcode-span context, ahead of the match for the closing backtick allows matches in the R Extended syntax definition to eat up the matching closing backtick.  Moving the include: "R Extended.sublime-syntax" to after the patterns for matching the closing backtick and newline (for "invalid.illegal.non-terminated.raw.markdown") seems to fix the issue.

I think a similar issue may also exist for the fenced code block. Although I have not been able to break it, placing the -include "R Extended.sublime-syntax" after the match pattern for the closing backticks seems to be more consistent.